### PR TITLE
Update handle.py - sdx path replaced with uuid

### DIFF
--- a/VMEncryption/main/handle.py
+++ b/VMEncryption/main/handle.py
@@ -769,6 +769,8 @@ def enable_encryption_format(passphrase, encryption_marker, disk_util):
                         logger.log(msg = ("format disk {0} failed".format(encrypted_device_path, format_disk_result)), level = CommonVariables.ErrorLevel)
                     crypt_item_to_update = CryptItem()
                     crypt_item_to_update.mapper_name = mapper_name
+                    if device_to_encrypt_uuid_path == dev_path_in_query:
+                        device_to_encrypt_uuid_path = disk_util.query_dev_uuid_path_by_sdx_path(sdx_path = dev_path_in_query)
                     crypt_item_to_update.dev_path = device_to_encrypt_uuid_path
                     crypt_item_to_update.luks_header_path = "None"
                     crypt_item_to_update.file_system = file_system


### PR DESCRIPTION
Addressed an issue - uuid of newly attached disks will be assigned ONLY after luksFormat, yet we still want uuid to be written into the /var/lib/azure_crypt_mount file as dev path, coz the sdx path for attached disks CAN change after reboot. 

We found the issue appeared on several of our VMs running CentOS 7.2.1511 with multiple attached data disks. The VM encryption extension mounted incorrect disks (though luksOpen throws no exception since all disks shared the same passphrase file per VM).